### PR TITLE
fix(responsive): fix sidebar breakpoint to @screen-sm-max

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
     "ovh-manager-webfont": "^1.0.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.5.x"
+    "angular-mocks": "~1.5.x",
+    "ovh-ui-kit": "^2.3.0"
   }
 }

--- a/less/ovh-angular-sidebar-menu.dist.less
+++ b/less/ovh-angular-sidebar-menu.dist.less
@@ -1,3 +1,4 @@
-@import "ovh-angular-sidebar-menu.less";
+@import "../bower_components/ovh-ui-kit/packages/oui-responsive/_variables";
+@import "ovh-angular-sidebar-menu";
 
-@screen-sm-min: 993px;
+@screen-sm-max: (@oui-responsive-breakpoint-tablet - 1px);

--- a/less/ovh-angular-sidebar-menu.less
+++ b/less/ovh-angular-sidebar-menu.less
@@ -1,7 +1,7 @@
 // SIDEBAR VARS
 //
 @SIDEBAR_MENU_OFFSET_TOP                 : 44px;                // for new topnav integration
-@SIDEBAR_MENU_Z_INDEX                    : 1040;
+@SIDEBAR_MENU_Z_INDEX                    : 1020;
 @SIDEBAR_MENU_OPACITY                    : 0.6;
 @SIDEBAR_MENU_ACTIVE_COLOR               : #ffffff;  //By default
 @SIDEBAR_MENU_TEXT_ACTIVE_COLOR          : #17273B;
@@ -402,7 +402,7 @@
 }
 
 //mobile
-@media (max-width: @screen-sm-min) {
+@media (max-width: @screen-sm-max) {
     #sidebar-menu {
         height             : 100%;
         padding-top        : @SIDEBAR_MENU_MOBILE_TOP_NAV_HEIGHT;


### PR DESCRIPTION
Change the breakpoint to `@screen-sm-max` to hide the sidebar for mobile and tablet.
The navbar has the responsive menu for these devices.

We can't have the hamburger menu and the sidebar displayed at the same time.

The main layout of each managers will need to be updated (eg. remove the fallback col-sm-* for the sidebar)