### PR TITLE
fix: fix automatic menu item closing on change state

### DIFF
--- a/src/ovh-angular-sidebar-menu.provider.js
+++ b/src/ovh-angular-sidebar-menu.provider.js
@@ -379,6 +379,14 @@ angular.module("ovh-angular-sidebar-menu").provider("SidebarMenu", function () {
                     }
                     if (stateInfos.included) {
                         return item.loadSubItems().then(function () {
+                            // Automatically close same level opened item if it is not current one
+                            var openedItem = _.find(sidebarMenuService.getAllMenuItems(), { isOpen: true, level: item.level });
+                            var someItemIsOpened = openedItem != null;
+
+                            if (someItemIsOpened && openedItem.id !== item.id) {
+                                openedItem.toggleOpen();
+                            }
+
                             if (item.hasSubItems() && !item.isOpen) {
                                 item.toggleOpen();
                             }


### PR DESCRIPTION
## fix automatic menu item closing on change state

### Description of the change

Menu item was closed when changing manually of selected item (e.g: user clicking on menu item) but when state automatically changed, previous menu item stayed open 

