### PR TITLE
build(deps): upgrade ng-ovh-actions-menu to v5.0.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "stylelint-config-standard": "^18.2.0"
   },
   "peerDependencies": {
+    "@ovh-ux/ng-ovh-actions-menu": "^5.0.0-alpha.0",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "1.6.10",
     "angular-translate": "^2.17.0",
     "angular-vs-repeat": "^2.0.9",
     "lodash": "~3.0.1",
-    "ovh-angular-actions-menu": "^4.0.0",
     "ovh-ui-kit": "^2.21.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@
  */
 
 import angular from 'angular';
+
+import '@ovh-ux/ng-ovh-actions-menu';
 import '@uirouter/angularjs';
 import 'angular-translate';
-import 'ovh-angular-actions-menu';
 
 import ngOvhSidebarMenuList from './list';
 
@@ -24,10 +25,10 @@ const moduleName = 'ngOvhSidebarMenu';
 
 angular
   .module(moduleName, [
-    'ui.router',
-    'pascalprecht.translate',
-    'ovh-angular-actions-menu',
+    'ngOvhActionsMenu',
     ngOvhSidebarMenuList,
+    'pascalprecht.translate',
+    'ui.router',
   ])
   .provider('SidebarMenu', provider)
   .directive('sidebarMenu', directive)

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,6 +786,13 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
+"@ovh-ux/ng-ovh-actions-menu@^5.0.0-alpha.0":
+  version "5.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-actions-menu/-/ng-ovh-actions-menu-5.0.0-alpha.0.tgz#734b82586e15b8d3129bde5ab5625042db14d558"
+  integrity sha512-cl7GCchFc6apUUXuaASNXpEWd8znR2sQt8ntu9FHTfB/G1trdFaKpzVfm87eABW+LuXi0s8FSi1RrcyTEF8Vlw==
+  dependencies:
+    lodash "^4.17.11"
+
 "@ovh-ux/rollup-plugin-less-tilde-importer@^1.0.0-beta.0":
   version "1.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/@ovh-ux/rollup-plugin-less-tilde-importer/-/rollup-plugin-less-tilde-importer-1.0.0-beta.0.tgz#eaf065c6e1fd039db0ddfb2f30955aec987e0c63"


### PR DESCRIPTION
## :arrow_up: Upgrade `ng-ovh-actions-menu` to `v5.0.0-alpha.0`

### Description of the Change

ffc31a0 - build(deps): upgrade ng-ovh-actions-menu to v5.0.0-alpha.0